### PR TITLE
Progress bar uses pure CSS animation instead of setInterval

### DIFF
--- a/src/Layout/Footer/Footer.js
+++ b/src/Layout/Footer/Footer.js
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 /** Utils */
-import { ProgressBarConstants } from '@utils/constants';
 /** Components */
 import ProgressBar from './ProgressBar';
 import NowPlaying from './NowPlaying';
@@ -9,37 +8,15 @@ import NowPlaying from './NowPlaying';
 import { FooterContainer, FooterWrapper } from './footer.styled';
 
 const Footer = () => {
-  const [songPosition, setSongPosition] = useState(0);
-  const [songInterval, setSongInterval] = useState(0);
-
   const current = useSelector(state => state.playing.current);
-
-  const { position: currentPosition } = useSelector(
-    state => state.playing.current
-  );
-
-  useEffect(() => {
-    if (currentPosition !== undefined) {
-      setSongPosition(currentPosition);
-      songInterval && clearInterval(songInterval);
-      setSongInterval(
-        setInterval(() => {
-          setSongPosition(
-            prevSongPosition =>
-              prevSongPosition + ProgressBarConstants.INTERVAL_DURATION
-          );
-        }, ProgressBarConstants.INTERVAL_DURATION)
-      );
-    } else {
-      setSongPosition(0);
-      clearInterval(songInterval);
-    }
-    return () => clearInterval(songInterval);
-  }, [currentPosition]);
 
   return (
     <FooterContainer>
-      <ProgressBar duration={current.duration} currentTime={songPosition} />
+      <ProgressBar
+        publicId={current.publicId}
+        duration={current.duration}
+        currentTime={current.position}
+      />
       <FooterWrapper className="footer">
         {current.title && <NowPlaying {...current} />}
       </FooterWrapper>

--- a/src/Layout/Footer/ProgressBar/ProgressBar.js
+++ b/src/Layout/Footer/ProgressBar/ProgressBar.js
@@ -3,17 +3,20 @@ import PropTypes from 'prop-types';
 /** Styled components */
 import { ProgressBarContainer, ProgressBarPlaying } from './ProgressBar.styled';
 
-const ProgressBar = ({ duration, currentTime }) => {
-  const currentPercentage = (currentTime / duration) * 100;
-
-  return (
-    <ProgressBarContainer>
-      <ProgressBarPlaying percentage={currentPercentage} />
-    </ProgressBarContainer>
-  );
-};
+const ProgressBar = ({ publicId, duration = 0, currentTime = 0 }) => (
+  <ProgressBarContainer>
+    {!!duration && !!currentTime && (
+      <ProgressBarPlaying
+        key={publicId}
+        duration={duration}
+        currentTime={currentTime}
+      />
+    )}
+  </ProgressBarContainer>
+);
 
 ProgressBar.propTypes = {
+  publicId: PropTypes.string,
   duration: PropTypes.number,
   currentTime: PropTypes.number,
 };

--- a/src/Layout/Footer/ProgressBar/ProgressBar.styled.js
+++ b/src/Layout/Footer/ProgressBar/ProgressBar.styled.js
@@ -1,7 +1,13 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const progressBarKeyFrames = keyframes`
+  0% { width: 0; }
+  100% { width: 100%; }
+`;
 
 const ProgressBarContainer = styled.div`
   width: 100%;
+  height: 10px;
   background-color: #d6d6d6;
   user-select: none;
   display: flex;
@@ -9,17 +15,13 @@ const ProgressBarContainer = styled.div`
   z-index: 3;
 `;
 
-const ProgressBarPlaying = styled.div.attrs(props => ({
-  style: {
-    width: `${
-      props.percentage ? (props.percentage > 100 ? 100 : props.percentage) : 0
-    }%`,
-  },
-}))`
+const ProgressBarPlaying = styled.div`
+  width: 100%;
   height: 10px;
   background: linear-gradient(to right, #835fc1, #01ab6d);
-  display: flex;
-  align-items: center;
+  animation: ${progressBarKeyFrames} ${props => props.duration / 1000}s linear
+    forwards;
+  animation-delay: -${props => props.currentTime / 1000}s;
 `;
 
 export { ProgressBarContainer, ProgressBarPlaying };


### PR DESCRIPTION
Fixes #14.

**Changes:**
- Instead of using JS setInterval to re-render the progress bar component in each interval, we use CSS animation.

**IMPORTANT NOTE:**
In order to reset the CSS animation when a song changes, we must use a unique key in the`ProgressBarPlaying` styled component. This way, everytime the song changes the animation will be reset since the key is unique.